### PR TITLE
Simplifly variables to use only var.infrastructure_provider

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,17 +13,17 @@ locals {
   argocd_namespace = "argocd"
 
   azure_addons = {
-    enable_azure_crossplane_upbound_provider = var.infrastructure_provider == "crossplane" && try(var.addons.enable_azure_crossplane_upbound_provider, false) ? true : false
-    enable_cluster_api_operator              = var.infrastructure_provider == "capz" && try(var.addons.enable_cluster_api_operator, false) ? true : false
+    enable_azure_crossplane_upbound_provider = var.infrastructure_provider == "crossplane" ? true : false
+    enable_cluster_api_operator              = var.infrastructure_provider == "capz" ? true : false
   }
 
   oss_addons = {
-    enable_argocd                          = try(var.addons.enable_argocd, false) # installed by default
+    enable_argocd                          = try(var.addons.enable_argocd, true) # installed by default
     enable_argo_rollouts                   = try(var.addons.enable_argo_rollouts, false)
     enable_argo_events                     = try(var.addons.enable_argo_events, false)
     enable_argo_workflows                  = try(var.addons.enable_argo_workflows, false)
     enable_cluster_proportional_autoscaler = try(var.addons.enable_cluster_proportional_autoscaler, false)
-    enable_cert_manager                    = var.infrastructure_provider == "capz" && var.addons.enable_cert_manager ? true : false
+    enable_cert_manager                    = var.infrastructure_provider == "capz" || try(var.addons.enable_cert_manager,false) ? true : false
     enable_gatekeeper                      = try(var.addons.enable_gatekeeper, false)
     enable_gpu_operator                    = try(var.addons.enable_gpu_operator, false)
     enable_ingress_nginx                   = try(var.addons.enable_ingress_nginx, false)
@@ -33,9 +33,9 @@ locals {
     enable_prometheus_adapter              = try(var.addons.enable_prometheus_adapter, false)
     enable_secrets_store_csi_driver        = try(var.addons.enable_secrets_store_csi_driver, false)
     enable_vpa                             = try(var.addons.enable_vpa, false)
-    enable_crossplane                      = var.infrastructure_provider == "crossplane" && try(var.addons.enable_crossplane, false) ? true : false
-    enable_crossplane_helm_provider        = var.infrastructure_provider == "crossplane" && try(var.addons.enable_crossplane_helm_provider, false) ? true : false
-    enable_crossplane_kubernetes_provider  = var.infrastructure_provider == "crossplane" && try(var.addons.enable_crossplane_kubernetes_provider, false) ? true : false
+    enable_crossplane                      = var.infrastructure_provider == "crossplane" ? true : false
+    enable_crossplane_helm_provider        = var.infrastructure_provider == "crossplane" ? true : false
+    enable_crossplane_kubernetes_provider  = var.infrastructure_provider == "crossplane" ? true : false
   }
   addons = merge(local.azure_addons, local.oss_addons)
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -33,12 +33,6 @@ variable "addons" {
   type        = any
   default = {
     enable_argocd                            = true # installs argocd
-    enable_cert_manager                      = true # installs cert manager
-    enable_crossplane                        = true # installs crossplane core
-    enable_azure_crossplane_upbound_provider = true # installs azure upbound provider
-    enable_cluster_api_operator              = true # installs azure api operator
-    enable_crossplane_helm_provider          = true # installs crossplane helm provider
-    enable_crossplane_kubernetes_provider    = true # installs crossplane kubernetes provider
   }
 }
 


### PR DESCRIPTION
## Purpose

If Terraform is run with an incomplete set of variables, we need to provide a default value or the plan will fail.

For example when using crossplane if I dont specify a value for  `var.addons.enable_cluster_api_operator` the terraform plan will fail with `This object does not have an attribute named "enable_cluster_api_operator".`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

