### PR TITLE
Bump cluster-api-operator to 0.9.3

### DIFF
--- a/gitops/bootstrap/control-plane/addons/azure/addons-azure-cluster-api-operator.yaml
+++ b/gitops/bootstrap/control-plane/addons/azure/addons-azure-cluster-api-operator.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: cluster-api-operator
                 addonChartNamespace: capi-operator-system
-                addonChartVersion: 0.9.2
+                addonChartVersion: 0.9.3
                 addonChartRepository: https://kubernetes-sigs.github.io/cluster-api-operator
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 0.9.2
+                addonChartVersion: 0.9.3
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 0.9.2
+                addonChartVersion: 0.9.3
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}


### PR DESCRIPTION
## Purpose

We need this fixed that was merged in 0.9.3
https://github.com/kubernetes-sigs/cluster-api-operator/pull/489
