### PR TITLE
Bump CAPI Operator to forked version v0.10.4

### DIFF
--- a/gitops/bootstrap/control-plane/addons/azure/addons-azure-cluster-api-operator.yaml
+++ b/gitops/bootstrap/control-plane/addons/azure/addons-azure-cluster-api-operator.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: cluster-api-operator
                 addonChartNamespace: capi-operator-system
-                addonChartVersion: 0.10.3
+                addonChartVersion: 0.10.4
                 addonChartRepository: https://willie-yao.github.io/cluster-api-operator
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 0.10.3
+                addonChartVersion: 0.10.4
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 0.10.3
+                addonChartVersion: 0.10.4
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This PR bumps CAPI Operator to v0.10.4 which removes the unnecessary sleep job.
