### PR TITLE
Crossplane to use ArgoCD version variable

### DIFF
--- a/gitops/clusters/crossplane/base/cluster/aks-composition.yaml
+++ b/gitops/clusters/crossplane/base/cluster/aks-composition.yaml
@@ -331,8 +331,8 @@ spec:
             chart:
               name: argo-cd
               repository: https://argoproj.github.io/argo-helm
-              version:  7.3.4
-            namespace: argocd   
+              version:  '{{metadata.labels.argocd_chart_version}}'
+            namespace: argocd
           providerConfigRef:
             name: helm-provider	
       patches:
@@ -378,7 +378,7 @@ spec:
                 source:    
                   repoURL: https://github.com/Azure-Samples/aks-platform-engineering
                   targetRevision: HEAD
-                  path: gitops/bootstrap/workloads
+                  path: gitops/bootstrap/workloads/infra
                 syncPolicy:
                   automated: {}
                 destination:


### PR DESCRIPTION
## Purpose
* ArgoCD install using Crossplane to bootstrap workload clusters using same variable for version.
* The Crossplane workload cluster to bootstrap to the `/infra` folder to match CAPZ

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```