### PR TITLE
Add kubecontext check

### DIFF
--- a/docs/Onboard-New-Dev-Team.md
+++ b/docs/Onboard-New-Dev-Team.md
@@ -1,5 +1,16 @@
 # Onboarding New Dev Team
 
+<!-- ADDED -->
+> **Important:** Before applying any changes or creating new ArgoCD applications, make sure your current kubecontext is pointing to the **management cluster**.  
+> You can verify with:
+> ```bash
+> kubectl config current-context
+> ```
+> If needed, switch to the correct context:
+> ```bash
+> kubectl config use-context <management-cluster-context>
+> ```
+
 Now that the management cluster is up and running, the next step is to onboard a new development team. This involves creating new workload cluster(s) and necessary infrastructure for the team to deploy their applications.
 
 ## Setup a new Team infrastructure using ArgoCD


### PR DESCRIPTION
Added short note in the README reminding users to verify the management cluster context before creating new ArgoCD apps.  
This prevents accidental deployments to the wrong cluster and ensures consistent management of team infrastructure.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Ensure users confirm they’re using the correct kubecontext (management cluster) to avoid misconfigurations.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  **No code changes required** – verify the updated README content.

## What to Check
* Confirm the README accurately instructs users to check and switch to the management cluster context.

## Other Information
* N/A